### PR TITLE
[Doc] Update doc on filters (calbacks)

### DIFF
--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -255,3 +255,7 @@ In this example, ``getWithOpenCommentField`` and ``getWithOpenCommentFilter`` im
             return true;
         }
     }
+
+.. note::
+
+    If you add a "groupBy" clause to your query, you will have incompatibility issue with the Pager. To prevent this, the easier way is to switch to the alternative "simple pager". See instruction at https://sonata-project.org/bundles/admin/master/doc/cookbook/recipe_improve_performance_large_datasets.html


### PR DESCRIPTION
Following the doc on doctrine_orm_callback filters, I ran into issue after adding a groupBy clause : 

```
// callback function :
    if (!is_array($value) or !array_key_exists('value', $value)
      or empty($value['value'] or $value['value'] === 0)) {
      return;
    }
    $queryBuilder->leftJoin(sprintf('%s.comments', $alias), 'c');
    $queryBuilder->groupBy($alias);
    $queryBuilder->having('count(c.id) > 0');
    return true;
```

=> lead to DoctrineNonUniqueException, caused by the pager.
After investigation, it looks like the simple way to get rid of it is to just switch the admin service to using the simple pager_type. Maybe it would be worth adding it to the doc ?
